### PR TITLE
Gradient Color add right side of the about section 🤧

### DIFF
--- a/sections/About.jsx
+++ b/sections/About.jsx
@@ -7,8 +7,9 @@ import styles from '../styles';
 import { fadeIn, staggerContainer } from '../utils/motion';
 
 const About = () => (
-  <section>
-    About section
+    <section className={`${styles.paddings} relative z-10`}>
+        <div className="gradient-02 z-0" />
+        About section
   </section>
 );
 


### PR DESCRIPTION
1. gradient-02 [temporary] .gradient-02 {
  position: absolute;
  width: 200px;
  height: 438px;
  top: 0px;
  right: 0px;

  background: #7aebfb;
  filter: blur(190px);
}

2. Z-Index Utilities for controlling the stack order of an element. https://tailwindcss.com/docs/z-index