### PR TITLE
Arrow-Down SVG Set with Motion Animation ⬇️

### DIFF
--- a/sections/About.jsx
+++ b/sections/About.jsx
@@ -17,7 +17,7 @@ const About = () => (
             className={`${styles.innerWidth} mx-auto ${styles.flexCenter} flex-col`}
         >
             <TypingText title="| About CodeXam" textStyles="text-center" />
-        </motion.div>
+
         <motion.p
             variants={fadeIn('up', 'tween', 0.2, 1)}
             className="mt-[8px] font-normal sm:text-[32px] text-[20px] text-center text-secondary-white"
@@ -31,7 +31,14 @@ const About = () => (
             <span className="font-extrabold text-white">explore</span> the world
             of the CodeXam by scrolling down
         </motion.p>
-        About section
+            <motion.img
+                variants={fadeIn('up', 'tween', 0.3, 1)}
+                src="/arrow-down.svg"
+                alt="arrow down"
+                className="w-[18px] h-[28px] object-contain mt-[28px]"
+            />
+
+        </motion.div>
   </section>
 );
 


### PR DESCRIPTION
- </motion.div> fixed
- <motion.img -> for arrow image animation
- variants={fadeIn('up', 'tween', 0.3, 1)} ° Direction -> direction up means from bottom to top ° Tween  ->  Set type to "tween" to use a duration-based animation. If any non-orchestration transition values are set without a type property, this is used as the default animation. ○ https://www.framer.com/docs/transition/#tween
° 0.3 ->  0.3 is the delay
° 1 is the duration of the animation
- className="w-[18px] h-[28px] object-contain mt-[28px]"

°  w-[18px] means width: 18px and h-[28px] means height: 28px and object-contain means the image will be contained in the container and the image will not be stretched or squished to fit the container and mt-[28px] means margin-top: 28px